### PR TITLE
hack: fix typo in example init script

### DIFF
--- a/hack/init_new_example.sh
+++ b/hack/init_new_example.sh
@@ -99,7 +99,7 @@ CFLAGS_USE_LIB${UCNAME} :=  \$(CPPFLAGS_USE_LIB${UCNAME})
 
 
 # 2. Rule to  build the objects (requires seatract include)
-\$(${NAME}_LIB${UCNAME}_OBJ_DIR)/%.o: \$(LIB${UCNAME}_SRC_DIR)/%.c \$(SEATRACT_H) \$(LIB${UCNAME}_HDR) \$(LIB${UCNAME}_OBJ_DIR) \$(${NAME}_LIB_SRC)/%.c
+\$(LIB${UCNAME}_OBJ_DIR)/%.o: \$(LIB${UCNAME}_SRC_DIR)/%.c \$(SEATRACT_H) \$(LIB${UCNAME}_HDR) \$(LIB${UCNAME}_OBJ_DIR)
 		\$(CC) \$(CFLAGS) \$(GLOBAL_CFLAGS) -c \$< -o \$@
 
 \$(LIB${UCNAME}_OBJ_DIR):

--- a/hack/init_new_example.sh
+++ b/hack/init_new_example.sh
@@ -99,7 +99,7 @@ CFLAGS_USE_LIB${UCNAME} :=  \$(CPPFLAGS_USE_LIB${UCNAME})
 
 
 # 2. Rule to  build the objects (requires seatract include)
-\$(${NAME}_LIB${UCNAME}_OBJ_DIR)/%.o: \$(LIB${UCNAME}_SRC_DIR)/%.c \$(SEATRACT_H) \$(LIB${UCNAME}_HDR) \$(LIB${UCNAME}_OBJ_DIR)D \$(${NAME}_LIB_SRC)/%.c
+\$(${NAME}_LIB${UCNAME}_OBJ_DIR)/%.o: \$(LIB${UCNAME}_SRC_DIR)/%.c \$(SEATRACT_H) \$(LIB${UCNAME}_HDR) \$(LIB${UCNAME}_OBJ_DIR) \$(${NAME}_LIB_SRC)/%.c
 		\$(CC) \$(CFLAGS) \$(GLOBAL_CFLAGS) -c \$< -o \$@
 
 \$(LIB${UCNAME}_OBJ_DIR):


### PR DESCRIPTION
This fixes a typo,
which seemed to have been a leftover of an incomplete vim command,
in the new-example init-script.