### PR TITLE
README: trim blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,3 @@ seatract is licensed under the GNU Lesser General Public License v3.0 or later (
 
 This allows seatract to be used in projects with more permissive licenses (like Apache 2.0 or MIT) 
 while ensuring that any improvements to seatract itself remain open source.
-
-
-
-
-
-


### PR DESCRIPTION
After the latest update, the readme had several trailing blank lines at the bottom.

This change removes those blank lines
to keep the document clean.